### PR TITLE
Fixed "Target due to target being out of range"

### DIFF
--- a/Entities/Targets/NaniteConstructionTargets.cs
+++ b/Entities/Targets/NaniteConstructionTargets.cs
@@ -126,6 +126,9 @@ namespace NaniteConstructionSystem.Entities.Targets
                     if (TargetList.Contains(item))
                         continue;
 
+                    if (EntityHelper.GetDistanceBetweenBlockAndSlimblock((IMyCubeBlock)m_constructionBlock.ConstructionBlock, item) > m_maxDistance)
+                        continue;
+
                     missing.Clear();
                     item.GetMissingComponents(missing);
                     bool foundMissingComponents = true;


### PR DESCRIPTION
DRAFT commit, should be buildable, do not have a development Environment right now.
But should work.

We wanted to build a tower, which is over 2km high:
![image](https://user-images.githubusercontent.com/1900106/43262328-074b2ce4-90e0-11e8-8af9-55b2d5215a09.png)

But nanite system keeps spinning up & down all the time, because of:
```
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=127183737150850759 position=[X:-9, Y:772, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=105480192629146549 position=[X:-9, Y:771, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=101034950557621261 position=[X:-9, Y:770, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=138557655758704942 position=[X:-9, Y:769, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=95113157481034269 position=[X:-9, Y:768, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=78964597156698058 position=[X:-9, Y:767, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=99590409686210500 position=[X:-9, Y:766, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=93846444808671248 position=[X:-9, Y:765, Z:-60]
[13:57:25] ADDING Construction/Repair Target: conid=86266717448755980 subtype=LargeBlockConveyor entityID=112668883239895811 position=[X:-9, Y:764, Z:-60]
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=127183737150850759,Position=[X:-9, Y:772, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 127183737150850759 Elapsed: 51041)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=105480192629146549,Position=[X:-9, Y:771, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 105480192629146549 Elapsed: 50974)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=101034950557621261,Position=[X:-9, Y:770, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 101034950557621261 Elapsed: 50908)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=138557655758704942,Position=[X:-9, Y:769, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 138557655758704942 Elapsed: 50841)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=95113157481034269,Position=[X:-9, Y:768, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 95113157481034269 Elapsed: 50775)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=78964597156698058,Position=[X:-9, Y:767, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 78964597156698058 Elapsed: 50708)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=99590409686210500,Position=[X:-9, Y:766, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 99590409686210500 Elapsed: 50642)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=93846444808671248,Position=[X:-9, Y:765, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 93846444808671248 Elapsed: 50575)
[13:57:28] TOOL started.  Target block: MyObjectBuilder_Conveyor/LargeBlockConveyor - 0ms - 72.5 0.0265507 72.5
[13:57:28] CANCELLING Repair Target due to target being out of range
[13:57:28] CANCELLING Construction/Repair Target: 86266717448755980 - MySlimBlock (EntityID=112668883239895811,Position=[X:-9, Y:764, Z:-60])
[13:57:28] TOOL completed.  Target block: MyConveyor - (EntityID: 112668883239895811 Elapsed: 50509)
```

With this PR i wanted to ensure, that only targets in range will be marked as possible targets.
Because only 1/5 of the tower grid is in nanite range, but the nanite system would like to build the blocks on top of the tower (tested with increasing the build range to 3km).