### PR TITLE
Projected blocks ownership fix

### DIFF
--- a/Data/Scripts/NaniteConstructionSystem/Entities/Targets/NaniteProjectionTargets.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Entities/Targets/NaniteProjectionTargets.cs
@@ -465,7 +465,7 @@ namespace NaniteConstructionSystem.Entities.Targets
 
                 if(projector.ProjectedGrid == block.CubeGrid)
                 {
-                    projector.Build(block, 0, m_constructionBlock.ConstructionBlock.EntityId, false);
+                    projector.Build(block, m_constructionBlock.ConstructionBlock.OwnerId, m_constructionBlock.ConstructionBlock.EntityId, false);
                     break;
                 }
             }


### PR DESCRIPTION
Blocks owner set to the owner of the Nanite Factory

Changing "Built By" field doesn't seem to be possible as it's set in [MyProjectorBase.Build](https://gist.github.com/vixfwis/e156ba539cac32c68b6baf451cedd74d) and not exposed to any whitelisted classes