### PR TITLE
Block was scanning for changes when off

### DIFF
--- a/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
+++ b/Data/Scripts/NaniteConstructionSystem/Entities/NaniteConstructionBlock.cs
@@ -518,7 +518,7 @@ namespace NaniteConstructionSystem.Entities
         /// </summary>
         private void ScanForTargets()
         {
-            if (DateTime.Now - m_lastUpdate > TimeSpan.FromSeconds(5) && m_ready)
+            if (DateTime.Now - m_lastUpdate > TimeSpan.FromSeconds(5) && m_ready && ConstructionBlock.IsWorking && ConstructionBlock.IsFunctional)
             {
                 //Logging.Instance.WriteLine(string.Format("ScanForTargets"));
                 m_ready = false;


### PR DESCRIPTION
Even when the nanite factory was turned off or not functional it was scanning for targets. I tested this in my own build, doesn't break anything from what I can tell in the latest V1 build. Just a thought here.